### PR TITLE
KK-7245: Add identifiers to associate audit log events

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ AuditLog.configure do
 end
 ```
 
+## Logging Additional Identifiers
+The gem supports logging additional identifiers from the auditable object. These are set to 'auditable_identifier_one' and 'auditable_identifier_two' by default and can be customized to any two identifiers in your app. Set them in your app's audit log configuration file to customise the identifiers.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/db/migrate/20240724100440_add_auditable_identifiers.rb
+++ b/db/migrate/20240724100440_add_auditable_identifiers.rb
@@ -1,0 +1,6 @@
+class AddAuditableIdentifiers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :audit_logs, :auditable_identifier_one, :string
+    add_column :audit_logs, :auditable_identifier_two, :string
+  end
+end

--- a/lib/audit-log.rb
+++ b/lib/audit-log.rb
@@ -15,6 +15,8 @@ module AuditLog
       @config = Configuration.new
       @config.user_name_method = "name"
       @config.table_name = "audit_logs"
+      @config.identifier_one_method = "auditable_identifier_one"
+      @config.identifier_two_method = "auditable_identifier_two"
       @config
     end
 
@@ -47,7 +49,9 @@ module AuditLog
             payload: payload,
             auditable: auditable,
             ownable: ownable,
-            request: request_info
+            request: request_info,
+            auditable_identifier_one: auditable.send(AuditLog.config.identifier_one_method),
+            auditable_identifier_two: auditable.send(AuditLog.config.identifier_two_method)
           )
         end
       end

--- a/lib/audit-log/configuration.rb
+++ b/lib/audit-log/configuration.rb
@@ -7,5 +7,8 @@ module AuditLog
 
     # set a special table_name for AuditLog Model, default: 'audit_logs'
     attr_accessor :table_name
+
+    #auditable identifiers methods, defaults: "auditable_identifier_one" and "auditable_identifier_two respectively"
+    attr_accessor :identifier_one_method, :identifier_two_method
   end
 end

--- a/lib/audit-log/version.rb
+++ b/lib/audit-log/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AuditLog
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
This PR updates the gem to include support for two auditable identifiers